### PR TITLE
Fixes internal migration determination logic and adds tests

### DIFF
--- a/charactersheet/charactersheet/services/persistence_service.js
+++ b/charactersheet/charactersheet/services/persistence_service.js
@@ -13,6 +13,36 @@ var PersistenceService = {
 };
 
 /**
+ * Given a table name, return all of the stored data objects in the table.
+ *
+ * Parameters
+ * ----------
+ *
+ * key: The string name of the table. This usually is the name of the model.
+ *
+ * Returns
+ * -------
+ *
+ * A list of raw data objects from the table.
+ *
+ * Note
+ * ----
+ *
+ * The objects returned by this method are raw objects containing an `id` and
+ * a data property. The raw `data` property contains the record's data.
+ *
+ * Usage
+ * -----
+ * ```javascript
+ * function Person() {...}
+ *
+ * var people = PersistenceService.findAllObjs('Person');```
+ */
+PersistenceService.findAllObjs = function(key) {
+    return PersistenceService._findAllObjs(key);
+};
+
+/**
  * Given a model class, return all of the stored instances of that class.
  *
  * Parameters

--- a/charactersheet/charactersheet/services/persistence_service.js
+++ b/charactersheet/charactersheet/services/persistence_service.js
@@ -455,33 +455,34 @@ PersistenceService._setVersion = function(appVersion) {
 };
 
 PersistenceService._shouldApplyMigration = function(appVersion, dbVersion, migration) {
-    //It is already assumed that the dbVersion and appVersion are different.
-    //Check the simple case first.
-    if (appVersion === migration.version) {
-        return true;
-    }
-
     //LEGACY: The db has no version number.
     if (!dbVersion) {
-        return true;
+        dbVersion = '0.0.0';
     }
 
+    var appAndDBVerionsDiffer = PersistenceService._compareVersions(appVersion, dbVersion);
+    var migrationVersionHigherThanDB = PersistenceService._compareVersions(migration.version, dbVersion);
+    var migrationVersionLowerOrEqualApp = !PersistenceService._compareVersions(migration.version, appVersion);
+
+    return appAndDBVerionsDiffer && migrationVersionHigherThanDB && migrationVersionLowerOrEqualApp;
+};
+
+PersistenceService._compareVersions = function(version1, version2) {
     //Parse the versions.
-    var appVersionNumbers = appVersion.split('.').map(function(e, i, _) {
+    var version1Numbers = version1.split('.').map(function(e, i, _) {
         return parseInt(e);
     });
-    var dbVersionNumbers = dbVersion.split('.').map(function(e, i, _) {
+    var version2Numbers = version2.split('.').map(function(e, i, _) {
         return parseInt(e);
     });
 
-    //Compare versions
-    for (i in appVersionNumbers) {
-        try {
-            if (appVersionNumbers[i] > dbVersionNumbers[i]) {
-                return true;
-            }
-        } catch(err) {
-            //The db version has no index for the given index.
+    //If any part of version 1 is higher than any part of version 2, return true.
+    for (var i in version1Numbers) {
+        if (version2Numbers[i] === undefined) {
+            return true;
+        }
+
+        if (version1Numbers[i] > version2Numbers[i]) {
             return true;
         }
     }

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -197,3 +197,24 @@ OtherStatsFixture = {
   'inspiration': 0,
   'proficiency': '2'
 };
+
+
+var MockLocalStorage = {
+    __master__: "[\"Character\",\"Profile\",\"PlayerInfo\",\"Skill\",\"Item\",\"CharacterAppearance\",\"FeaturesTraits\",\"Health\",\"OtherStats\",\"DeathSave\",\"HitDiceType\",\"AbilityScores\",\"SavingThrows\",\"SpellStats\",\"FeatsProf\",\"Treasure\",\"Note\",\"HitDice\",\"Spell\",\"Armor\",\"Slot\",\"Weapon\",\"DailyFeature\",\"ImageModel\"]",
+    Skill: "{\"18\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Acrobatics\",\"abilityScore\":\"Dex\",\"modifier\":null},\"19\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Animal Handling\",\"abilityScore\":\"Wis\",\"modifier\":null},\"20\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Arcana\",\"abilityScore\":\"Int\",\"modifier\":null},\"21\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Athletics\",\"abilityScore\":\"Str\",\"modifier\":null},\"22\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Deception\",\"abilityScore\":\"Cha\",\"modifier\":null},\"23\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"History\",\"abilityScore\":\"Int\",\"modifier\":null},\"24\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Insight\",\"abilityScore\":\"Wis\",\"modifier\":null},\"25\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Intimidation\",\"abilityScore\":\"Cha\",\"modifier\":null},\"26\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Investigation\",\"abilityScore\":\"Int\",\"modifier\":null},\"27\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Medicine\",\"abilityScore\":\"Wis\",\"modifier\":null},\"28\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Nature\",\"abilityScore\":\"Int\",\"modifier\":null},\"29\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Perception\",\"abilityScore\":\"Wis\",\"modifier\":null},\"30\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Performance\",\"abilityScore\":\"Cha\",\"modifier\":null},\"31\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Persuasion\",\"abilityScore\":\"Cha\",\"modifier\":null},\"32\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Religion\",\"abilityScore\":\"Int\",\"modifier\":null},\"33\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Sleight of Hand\",\"abilityScore\":\"Dex\",\"modifier\":null},\"34\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Stealth\",\"abilityScore\":\"Dex\",\"modifier\":null},\"35\":{\"characterId\":\"f563af87-1382-479d-8bb8-5f61145fc84d\",\"name\":\"Survival\",\"abilityScore\":\"Wis\",\"modifier\":null}}"
+};
+
+var mock_110_migration = {
+    name: 'TESTING MIGRATION',
+    version: '1.1.0',
+    migration: function() {
+
+    }
+};
+var mock_134_migration = {
+    name: 'TESTING MIGRATION',
+    version: '1.3.0',
+    migration: function() {
+
+    }
+};

--- a/test/services/test_persistence_service.js
+++ b/test/services/test_persistence_service.js
@@ -1,0 +1,86 @@
+'use strict';
+/*eslint no-console:0*/
+
+describe('Persistence Service', function() {
+    //Clean up after each test.
+    afterEach(function() {
+        simple.restore();
+    });
+
+    describe('Static Methods', function() {
+
+        // Find All
+
+        describe('Find All Objs', function() {
+            it('should return a list of raw data objects from it\'s data store.', function() {
+                simple.mock(PersistenceService, 'storage', MockLocalStorage);
+                var count = Object.keys(JSON.parse(MockLocalStorage.Skill)).length;
+                var objs = PersistenceService.findAllObjs('Skill');
+                objs.length.should.equal(count);
+            });
+        });
+        describe('Find All', function() {
+            it('should return a list of mapped model objects from it\'s data store.', function() {
+                simple.mock(PersistenceService, 'storage', MockLocalStorage);
+                var count = Object.keys(JSON.parse(MockLocalStorage.Skill)).length;
+                var objs = PersistenceService.findAll(Skill);
+                objs.length.should.equal(count);
+            });
+        });
+
+        // Save
+
+        describe('Save', function() {
+            it('should save a mapped model object to the data store', function() {
+                var _saveObjStub = simple.mock(PersistenceService, '_save');
+                _saveObjStub.called.should.equal(false);
+                PersistenceService.save(Skill, new Skill());
+                _saveObjStub.called.should.equal(true);
+            });
+        });
+        describe('Save Obj', function() {
+            it('should save a mapped model object to the data store', function() {
+                var _saveObjStub = simple.mock(PersistenceService, '_saveObj').callFn(function() {});
+                _saveObjStub.called.should.equal(false);
+                PersistenceService.saveObj('Skill', 1, new Skill());
+                _saveObjStub.called.should.equal(true);
+            });
+        });
+
+        // Migrations
+
+        describe('Should Apply Migration', function() {
+            it('should determine if a migration should be applied. (true)', function() {
+                var result = PersistenceService._shouldApplyMigration('1.1.0', undefined, mock_110_migration);
+                result.should.equal(true);
+            });
+            it('should determine if an unmet migration should be applied. (false)', function() {
+                var result = PersistenceService._shouldApplyMigration('0.1.0', undefined, mock_110_migration);
+                result.should.equal(false);
+            });
+            it('should determine if an old migration should be applied. (false)', function() {
+                var result = PersistenceService._shouldApplyMigration('1.1.3', '1.1.1', mock_110_migration);
+                result.should.equal(false);
+            });
+            it('should determine if migrations should be applied if there\'s no change in version. (false)', function() {
+                var result = PersistenceService._shouldApplyMigration('1.1.1', '1.1.1', mock_110_migration);
+                result.should.equal(false);
+            });
+            it('should determine if migrations should be applied if the prev version is incomplete. (true)', function() {
+                var result = PersistenceService._shouldApplyMigration('1.3.5', '1.3', mock_134_migration);
+                result.should.equal(true);
+            });
+        });
+
+        describe('Copy Using Keys', function() {
+            it('should copy the values of an object\'s keys', function() {
+                var copy = {};
+                PersistenceService._copyObjectUsingKeys(MockLocalStorage, copy);
+                JSON.stringify(copy).should.equal(JSON.stringify(MockLocalStorage));
+            });
+        });
+
+
+
+    });
+});


### PR DESCRIPTION
### Summary of Changes
- Fixes issues with `_shouldApplyMigrations` not working correctly.
- Adds `_copyObjectUsingKeys` to copy local storage and replace it.
- Adds tests for a few methods (more needed).
- Promotes `findAllObjs` to a public method, while preserving the internal API.
